### PR TITLE
Change remark_args to remark_flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ jobs:
 
 **Optional**. The directory to run remark-lint in. Defaults to `.`.
 
-#### `remark_args`
+#### `remark_flags`
 
-**Optional**. Additional remark-lint input arguments. Defaults to `""`.
+**Optional**. Additional remark-lint input flags. Defaults to `""`.
 
 ### `annotate`
 


### PR DESCRIPTION
Providing `remark_args` to the action yields the following warning:

> Warning: Unexpected input(s) 'remark_args', valid inputs are ['entryPoint', 'args', 'github_token', 'workdir', 'remark_flags', 'tool_name', 'level', 'reporter', 'filter_mode', 'fail_on_error', 'reviewdog_flags']

The documentation should probably reflect this and use `remark_flags` instead of `remark_args`.