### PR TITLE
Make `github_token` optional

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,7 @@ inputs:
   # Reviewdog related inputs
   github_token:
     description: "GITHUB_TOKEN."
-    required: true
+    required: false
     default: ${{ github.token }}
   tool_name:
     description: "Tool name to use for reviewdog reporter."


### PR DESCRIPTION
Make `github_token` optional. Resolves #60.