### PR TITLE
Update documentation for `github_token`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Remark presets are also installed when they are specified them in the `dependenc
 
 ### `github_token`
 
-**Required**. The [GITHUB_TOKEN](https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow). Must be in form of `github_token: ${{ secrets.github_token }}`. Defaults to `${{ github.token }}`.
+**Optional**. The [GITHUB_TOKEN](https://docs.github.com/en/free-pro-team@latest/actions/reference/authentication-in-a-workflow). Must be in form of `github_token: ${{ secrets.github_token }}`. Defaults to `${{ github.token }}`.
 
 ### `workdir`
 


### PR DESCRIPTION
Update documentation for `github_token` now that #61 is merged.