### PR TITLE
Add fail_level and deduplicate fail_on_error

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,16 @@ Remark presets are also installed when they are specified them in the `dependenc
 
 **Optional**. Filtering mode for the reviewdog command `[added, diff_context, file, nofilter]`. Defaults to `added`.
 
+### `fail_level`
+
+**Optional**. If set to `none`, always use exit code 0 for reviewdog.
+Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+Possible values: [`none`, `any`, `info`, `warning`, `error`]
+Default is `none`.
+
 ### `fail_on_error`
 
+Deprecated, use `fail_level` instead.
 **Optional**. Exit code for when reviewdog when errors are found `[true, false]`. Defaults to `false`.
 
 ### `reviewdog_flags`

--- a/action.yml
+++ b/action.yml
@@ -37,8 +37,16 @@ inputs:
     description: "Filtering mode for the reviewdog command [added, diff_context, file, nofilter]."
     required: false
     default: "added"
+  fail_level:
+    description: |
+      If set to `none`, always use exit code 0 for reviewdog.
+      Otherwise, exit code 1 for reviewdog if it finds at least 1 issue with severity greater than or equal to the given level.
+      Possible values: [none,any,info,warning,error]
+      Default is `none`.
+    default: 'none'
   fail_on_error:
-    description: "Exit code for reviewdog when errors are found [true, false]."
+    description: "Deprecated, use `fail_level` instead. Exit code for reviewdog when errors are found [true, false]."
+    deprecationMessage: Deprecated, use `fail_level` instead.
     required: false
     default: "false"
   reviewdog_flags:
@@ -59,6 +67,7 @@ runs:
         INPUT_LEVEL: ${{ inputs.level }}
         INPUT_REPORTER: ${{ inputs.reporter }}
         INPUT_FILTER_MODE: ${{ inputs.filter_mode }}
+        INPUT_FAIL_LEVEL: ${{ inputs.fail_level }}
         INPUT_FAIL_ON_ERROR: ${{ inputs.fail_on_error }}
         INPUT_REVIEWDOG_FLAGS: ${{ inputs.reviewdog_flags }}
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,6 +45,7 @@ remark . ${INPUT_REMARK_ARGS} 2>&1 |
     -name="${INPUT_TOOL_NAME}" \
     -reporter="${INPUT_REPORTER}" \
     -filter-mode="${INPUT_FILTER_MODE}" \
+    -fail-level="${INPUT_FAIL_LEVEL}" \
     -fail-on-error="${INPUT_FAIL_ON_ERROR}" \
     -level="${INPUT_LEVEL}" \
     -tee \


### PR DESCRIPTION
In https://github.com/reviewdog/reviewdog/pull/1854, we add `-fail-level` to reviewdog and deduplicate `-fail-on-error`.
I apply it to this actions.